### PR TITLE
AB#28875: Add configuration to fetch all history

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,8 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - uses: actions/setup-node@v3
       with:
         node-version: 18


### PR DESCRIPTION
This commit will affect other services that are reusing this action. However scanning all history will provide accurate SonarCloud analysis.