### PR TITLE
AB-31838: Increase actions/checkout version to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: actions/setup-node@v3


### PR DESCRIPTION
This commit inceases actions/checkout version to latest which is v4