### PR TITLE
fix: AB#35950 Allow checking out a different branch than the current branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,12 +10,24 @@ inputs:
   repo:
     description: "Name of the repo calling this action"
     required: true
+  branch:
+    description: "branch to use for the run"
+    required: false
+    type: string
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+    - if: ${{ !inputs.branch }}
+        name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+    - if: ${{ inputs.branch }}
+        name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.branch }}
     - uses: actions/setup-node@v4
       with:
         node-version: 20


### PR DESCRIPTION
Description:
Allows specifying the branch to checkout. This will allow the E2E scheduled runs to specify which branch to run against so that  the tests match the deployed code in each environment.

Ticket:
[Bug 35950](https://dev.azure.com/qcyberdevops/Dev/_workitems/edit/35950): E2E Tests running dev tests against all environments
